### PR TITLE
- no need to be bound to a specific toolchain 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,26 @@
 project (DASH)
 cmake_minimum_required (VERSION 3.5)
 
-set(CMAKE_CXX_COMPILER "g++")
-set(CMAKE_CXX_FLAGS "-std=c++17 -g")
-
 include_directories(include)
 include_directories(manifest)
 
 file(GLOB LIBSOURCES "parser/*.cpp" "mpd/*.cpp")
 add_library(ltDash STATIC ${LIBSOURCES})
 
+set_target_properties(ltDash PROPERTIES
+    CXX_STANDARD 17
+    CXX_EXTENSIONS TRUE
+)
+
+
+
 file(GLOB SOURCES "test/*.cpp")
 
 set(test DashTest )
 add_executable(test ${SOURCES})
 target_link_libraries(test ltDash "-lexpat")
+
+set_target_properties(test PROPERTIES
+    CXX_STANDARD 17
+    CXX_EXTENSIONS TRUE
+)


### PR DESCRIPTION
 No need to be bound to a specific toolchain (ARM toolchain build error fix).